### PR TITLE
🩹 현재 active한 시간표만 삭제 가능하도록 수정, 삭제 버튼 클릭 시 이름 변경 모달이 같이 뜨는 버그 픽스

### DIFF
--- a/e2e/main/timetable-section.spec.ts
+++ b/e2e/main/timetable-section.spec.ts
@@ -128,9 +128,12 @@ test('로그인되었을 경우, 시간표 생성 기능이 정상 동작한다 
 test('로그인되었을 경우, 시간표 삭제 기능이 정상 동작한다', async ({ page }) => {
   await page.goto('/?year=1001&semester=1');
   await givenUser(page, { login: true });
-
   const tabs = page.getByTestId('mt-tab');
+
   await tabs.filter({ hasText: '나무의 시간표' }).locator('[data-testid=mt-tab-delete]').click();
+  await expect(page.getByText('삭제하시겠습니까?')).toHaveCount(0); // active하지 않으므로, 모달이 열리는 대신 탭이 선택됨
+  await tabs.filter({ hasText: '나무의 시간표' }).locator('[data-testid=mt-tab-delete]').click();
+  await expect(page.getByText('시간표 이름을 변경합니다')).toHaveCount(0); // 시간표 이름 변경 모달이 같이 뜨는 이슈가 있어서 추가된 tc
   await expect(page.getByTestId('mt-tt-delete-submit')).toBeDisabled();
   await page.getByTestId('mt-tt-delete-input').type('나무의 시간표');
   await Promise.all([

--- a/src/pages/main/main-timetable-section/index.tsx
+++ b/src/pages/main/main-timetable-section/index.tsx
@@ -68,9 +68,10 @@ export const MainTimetableSection = ({
               value={id}
               aria-selected={isActive}
               key={id}
-              onClick={() => (isActive ? setRenameTimetableDialogId(id) : changeCurrentTimetable(id))}
+              onClick={() => changeCurrentTimetable(id)}
             >
-              {title} <CloseIcon data-testid="mt-tab-delete" onClick={() => setDeleteTimetableDialogId(id)} />
+              <span onClick={() => isActive && setRenameTimetableDialogId(id)}>{title}</span>
+              <CloseIcon data-testid="mt-tab-delete" onClick={() => isActive && setDeleteTimetableDialogId(id)} />
             </Tabs.Tab>
           );
         })}
@@ -129,6 +130,7 @@ const Content = styled.div`
 `;
 
 const CloseIcon = styled(IcClose)`
+  margin-left: 4px;
   opacity: 0.6;
   transition: opacity 0.1s;
 


### PR DESCRIPTION
resolves https://wafflestudio.slack.com/archives/C8M9NUBBR/p1675398770682699?thread_ts=1675339858.768509&cid=C8M9NUBBR