### PR TITLE
🩹 강의 시간 업데이트 시 startMinute 같이 보내는 버그 픽스

### DIFF
--- a/src/pages/main/main-lecture-edit-dialog/index.tsx
+++ b/src/pages/main/main-lecture-edit-dialog/index.tsx
@@ -41,7 +41,12 @@ export const MainLectureEditDialog = ({ open, onClose, timetableId, lecture }: P
 
     mutate(
       {
-        class_time_json: draft.class_time_json?.map((t) => lectureService.removeInternalId(t)),
+        class_time_json: draft.class_time_json?.map((t) => ({
+          day: t.day,
+          start_time: t.start_time,
+          end_time: t.end_time,
+          place: t.place,
+        })),
         course_title: draft.course_title,
         credit: draft.credit,
         instructor: draft.instructor,


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1705915430019219?thread_ts=1705915124.773949&cid=C0PAVPS5T